### PR TITLE
Replace absolute sizing on header image with fluid/max-width

### DIFF
--- a/_includes/css/header.css
+++ b/_includes/css/header.css
@@ -25,6 +25,11 @@
   background-color: #dfd1cd;
 }
 
+#logo-wrapper img {
+  width: 100%;
+  max-width: 371px;
+}
+
 @media (min-width: 768px) {
   .navbar-nav>li>a {
     padding-top: 5px;

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -36,6 +36,6 @@
 
 <div id="logo-wrapper">
   <div class="container">
-      <a href="{{ site.baseurl }}/"><img src="{{ site.baseurl }}/img/logo.png" width="371" height="69" alt="OpenElections logo"></a>
+      <a href="{{ site.baseurl }}/"><img src="{{ site.baseurl }}/img/logo.png" alt="OpenElections logo"></a>
   </div>
 </div>


### PR DESCRIPTION
Make header image fluid so it doesn't force the viewport to be too large on mobile devices.

![image](https://cloud.githubusercontent.com/assets/1609616/2534006/ce1f565c-b56f-11e3-847d-df24c3bf6d65.png)
