### PR TITLE
Fix the map

### DIFF
--- a/js/render-map.js
+++ b/js/render-map.js
@@ -104,7 +104,7 @@
 
   function render() {
     // Bind data and create one path per GeoJSON feature
-    var path = svg.selectAll("path")
+    var paths = svg.selectAll("path")
       .data(geo.features)
       .enter()
       .append('a')


### PR DESCRIPTION
The map wasn't rendering on initial page load.  I realized that
the same variable name `path` was being used for both the d3
path generator and the d3 selector for `path` SVG elements. It
seems like it should have worked, but it's sloppy coding to use
the same variable name anyway.