### PR TITLE
Fix URLs in home page results map

### DIFF
--- a/js/render-map.js
+++ b/js/render-map.js
@@ -108,7 +108,7 @@
       .data(geo.features)
       .enter()
       .append('a')
-      .attr("xlink:href", function(d) { return "http://www.openelections.net/results#"+d.properties.postal.toLowerCase(); })
+      .attr("xlink:href", function(d) { return "http://www.openelections.net/results/#"+d.properties.postal.toLowerCase(); })
       .append("path")
       .attr("d", path)
       .attr("class", function(d) {


### PR DESCRIPTION
Clicking on a state currently directs the user to a URL that times out.

`/results/` works as expected, but `/results` (without the trailing slash) redirects to <http://www.openelections.net:8001/results/>, which simply times out.

Since the site's nav bar points to `/results/`, this just updates the map to do the same.